### PR TITLE
  結果画面のミス表示改善とキーボードの視認性向上

### DIFF
--- a/src/components/OnScreenKeyboard.tsx
+++ b/src/components/OnScreenKeyboard.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from 'react';
 
 interface OnScreenKeyboardProps {
-  lastTypedKey?: string | null;
+  lastTypedKey: string | null;
   mistypedKeys?: { [key: string]: number };
 }
 
@@ -55,16 +55,16 @@ const OnScreenKeyboard: React.FC<OnScreenKeyboardProps> = ({ lastTypedKey, misty
       case 'tab':
       case 'capslock':
       case 'enter':
-        return `${baseClass} w-20`; // 幅広のキー
+        return `${baseClass} w-28 h-14 text-lg`;
       case 'shift':
-        return `${baseClass} w-24`; // さらに幅広のキー
+        return `${baseClass} w-[8.75rem] h-14 text-lg`;
       case 'space':
-        return `${baseClass} w-96`; // スペースキー
+        return `${baseClass} w-[32.5rem] h-14 text-lg`;
       case 'ctrl':
       case 'alt':
-        return `${baseClass} w-16`;
+        return `${baseClass} w-20 h-14 text-lg`;
       default:
-        return `${baseClass} w-10 h-10`; // 通常のキー
+        return `${baseClass} w-14 h-14 text-xl`;
     }
   };
 

--- a/src/components/ResultDisplay.tsx
+++ b/src/components/ResultDisplay.tsx
@@ -7,48 +7,44 @@ import OnScreenKeyboard from './OnScreenKeyboard';
 interface TypingResult {
   accuracy: number;
   wpm: number;
-  mistakes: { char: string; expected: string; actual: string; typedKey: string }[];
+  mistakes: { char: string; expected: string; actual: string; typedKey: string; kanaIndex: number }[];
   startTime: number;
   endTime: number;
-  totalKeystrokes: number; // 総打鍵数
-  correctKeystrokes: number; // 正解打鍵数
-  correctKanaUnits: number; // 正解仮名数
+  totalKeystrokes: number;
+  correctKeystrokes: number;
+  correctKanaUnits: number;
+  typedText: string;
 }
 
-interface MistakeAnalysis {
-  [char: string]: {
-    count: number;
-    patterns: { [pattern: string]: number };
-  };
+interface MistakeDetails {
+  [index: number]: { 
+    char: string;
+    expected: string;
+    actual: string; 
+  }[];
 }
 
 interface MistypedKeys {
   [key: string]: number;
 }
 
-const analyzeMistakes = (mistakes: TypingResult['mistakes']): MistakeAnalysis => {
-  const analysis: MistakeAnalysis = {};
-
+const createMistakeDetails = (mistakes: TypingResult['mistakes']): MistakeDetails => {
+  const details: MistakeDetails = {};
   mistakes.forEach(mistake => {
-    const { char, expected, actual } = mistake;
-    if (!analysis[char]) {
-      analysis[char] = { count: 0, patterns: {} };
+    if (!details[mistake.kanaIndex]) {
+      details[mistake.kanaIndex] = [];
     }
-    analysis[char].count++;
-
-    const pattern = `${expected} -> ${actual}`;
-    if (!analysis[char].patterns[pattern]) {
-      analysis[char].patterns[pattern] = 0;
-    }
-    analysis[char].patterns[pattern]++;
+    details[mistake.kanaIndex].push({
+      char: mistake.char,
+      expected: mistake.expected,
+      actual: mistake.actual 
+    });
   });
-
-  return analysis;
+  return details;
 };
 
 const analyzeMistypedKeys = (mistakes: TypingResult['mistakes']): MistypedKeys => {
   const analysis: MistypedKeys = {};
-
   mistakes.forEach(mistake => {
     const key = mistake.typedKey.toLowerCase();
     if (!analysis[key]) {
@@ -56,24 +52,33 @@ const analyzeMistypedKeys = (mistakes: TypingResult['mistakes']): MistypedKeys =
     }
     analysis[key]++;
   });
-
   return analysis;
 };
 
 const ResultDisplay: React.FC = () => {
   const [result, setResult] = useState<TypingResult | null>(null);
-  const [mistakeAnalysis, setMistakeAnalysis] = useState<MistakeAnalysis | null>(null);
+  const [mistakeDetails, setMistakeDetails] = useState<MistakeDetails | null>(null);
   const [mistypedKeys, setMistypedKeys] = useState<MistypedKeys | null>(null);
+  const [tooltip, setTooltip] = useState<{ content: string; x: number; y: number } | null>(null);
 
   useEffect(() => {
     const storedResult = localStorage.getItem('typingResult');
     if (storedResult) {
       const parsedResult: TypingResult = JSON.parse(storedResult);
       setResult(parsedResult);
-      setMistakeAnalysis(analyzeMistakes(parsedResult.mistakes));
+      setMistakeDetails(createMistakeDetails(parsedResult.mistakes));
       setMistypedKeys(analyzeMistypedKeys(parsedResult.mistakes));
     }
   }, []);
+
+  const handleMouseOver = (e: React.MouseEvent<HTMLSpanElement>, details: {char: string, expected: string, actual: string}[]) => {
+    const content = details.map(d => `「${d.char}」で「${d.expected}」を「${d.actual}」と入力`).join('\n');
+    setTooltip({ content, x: e.clientX, y: e.clientY });
+  };
+
+  const handleMouseLeave = () => {
+    setTooltip(null);
+  };
 
   if (!result) {
     return (
@@ -93,47 +98,56 @@ const ResultDisplay: React.FC = () => {
 
   return (
     <div className="flex flex-col items-center justify-center w-full">
+      {tooltip && (
+        <div 
+          className="absolute bg-gray-800 text-white p-2 rounded shadow-lg z-10 whitespace-pre-wrap"
+          style={{ top: tooltip.y + 10, left: tooltip.x + 10 }}
+        >
+          {tooltip.content}
+        </div>
+      )}
       <div className="mb-8 p-8 bg-white rounded-lg shadow-lg min-w-[800px]">
         <h2 className="text-3xl font-bold text-gray-800 mb-4">タイピング結果</h2>
         <p className="text-xl text-gray-700 mb-2">正確性: {accuracyPercentage}%</p>
         <p className="text-xl text-gray-700 mb-2">タイピング速度 (WPM): {wpm}</p>
         <p className="text-xl text-gray-700 mb-4">総打鍵数: {result.totalKeystrokes} (正解打鍵数: {result.correctKeystrokes})</p>
 
+        {result.typedText && mistakeDetails && (
+          <div className="mt-8">
+            <h3 className="text-2xl font-bold text-gray-800 mb-3">文章内のミス</h3>
+            <div className="text-2xl leading-relaxed p-4 border rounded-lg bg-gray-50">
+              {result.typedText.split('').map((char, index) => {
+                const mistakesAtThisIndex = mistakeDetails[index];
+                if (mistakesAtThisIndex) {
+                  return (
+                    <span 
+                      key={index} 
+                      className="text-red-500 underline decoration-wavy cursor-pointer"
+                      onMouseMove={e => handleMouseOver(e, mistakesAtThisIndex)}
+                      onMouseLeave={handleMouseLeave}
+                    >
+                      {char}
+                    </span>
+                  );
+                }
+                return <span key={index}>{char}</span>;
+              })}
+            </div>
+          </div>
+        )}
+
         {mistypedKeys && (
           <div className="mt-8">
             <h3 className="text-2xl font-bold text-gray-800 mb-3">苦手なキー</h3>
             <OnScreenKeyboard mistypedKeys={mistypedKeys} />
+            <div className="flex items-center justify-center mt-2 text-gray-600">
+              <span>ミスが少ない</span>
+              <div className="w-32 h-4 mx-2 rounded-full bg-gradient-to-r from-red-200 to-red-600"></div>
+              <span>ミスが多い</span>
+            </div>
           </div>
         )}
 
-        {result.mistakes.length > 0 && (
-          <div className="mt-6">
-            <h3 className="text-2xl font-bold text-red-600 mb-3">ミスタイプ箇所一覧</h3>
-            <ul className="list-disc list-inside text-left max-h-60 overflow-y-auto">
-              {result.mistakes.map((mistake, index) => (
-                <li key={index} className="text-lg text-gray-800">
-                  <span className="font-semibold">文字:</span> {mistake.char}, <span className="font-semibold">期待されるローマ字:</span> {mistake.expected}, <span className="font-semibold">実際の入力:</span> {mistake.actual}
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-
-        {mistakeAnalysis && Object.keys(mistakeAnalysis).length > 0 && (
-          <div className="mt-8">
-            <h3 className="text-2xl font-bold text-gray-800 mb-3">ミス傾向分析</h3>
-            {Object.entries(mistakeAnalysis).map(([char, data]) => (
-              <div key={char} className="mb-4 p-3 border rounded-lg bg-gray-50">
-                <p className="text-lg font-semibold">「{char}」でのミス: {data.count}回</p>
-                <ul className="list-disc list-inside ml-4 text-base">
-                  {Object.entries(data.patterns).map(([pattern, count]) => (
-                    <li key={pattern}>「{pattern}」パターン: {count}回</li>
-                  ))}
-                </ul>
-              </div>
-            ))}
-          </div>
-        )}
       </div>
       <Link href="/" className="px-8 py-4 bg-blue-600 text-white text-2xl font-bold rounded-lg shadow-lg hover:bg-blue-700 transition duration-300">
         スタート画面に戻る

--- a/src/components/TypingGame.tsx
+++ b/src/components/TypingGame.tsx
@@ -16,12 +16,13 @@ const TYPING_TEXTS = [
 interface TypingResult {
   accuracy: number;
   wpm: number;
-  mistakes: { char: string; expected: string; actual: string; typedKey: string }[];
+  mistakes: { char: string; expected: string; actual: string; typedKey: string; kanaIndex: number }[];
   startTime: number;
   endTime: number;
   totalKeystrokes: number; // 総打鍵数
   correctKeystrokes: number; // 正解打鍵数
   correctKanaUnits: number; // 正解仮名数
+  typedText: string; // タイプした全文
 }
 
 // Helper function to break down text into typing units (handling 拗音 and 促音)
@@ -70,7 +71,7 @@ const TypingGame: React.FC = () => {
   const [totalKeystrokes, setTotalKeystrokes] = useState(0); // 総打鍵数
   const [correctKeystrokes, setCorrectKeystrokes] = useState(0); // 正解打鍵数
   const [correctKanaUnits, setCorrectKanaUnits] = useState(0); // 正解仮名数
-  const [mistakes, setMistakes] = useState<{ char: string; expected: string; actual: string; typedKey: string }[]>([]);
+  const [mistakes, setMistakes] = useState<{ char: string; expected: string; actual: string; typedKey: string; kanaIndex: number }[]>([]);
   const [isGameStarted, setIsGameStarted] = useState(false); // ゲーム開始状態
   const [flashCorrect, setFlashCorrect] = useState(false); // 正解時のフラッシュ
   const [lastTypedKey, setLastTypedKey] = useState<string | null>(null); // 最後に打たれたキー
@@ -102,6 +103,7 @@ const TypingGame: React.FC = () => {
       totalKeystrokes,
       correctKeystrokes,
       correctKanaUnits,
+      typedText: TYPING_TEXTS.join(""), // 全文を結合
     };
     localStorage.setItem('typingResult', JSON.stringify(result));
     router.push('/result');
@@ -200,7 +202,7 @@ const TypingGame: React.FC = () => {
     } else if (!isPartialMatch) {
       setError(true);
       const expectedRomajiForError = currentKana === 'っ' ? '次の子音' : getRomajiCandidates(currentKana).join('/');
-      setMistakes(prev => [...prev, { char: currentKana, expected: expectedRomajiForError, actual: newBuffer, typedKey: typedChar }]);
+      setMistakes(prev => [...prev, { char: currentKana, expected: expectedRomajiForError, actual: newBuffer, typedKey: typedChar, kanaIndex: currentKanaIndex }]);
       setInputBuffer(''); // エラー時はバッファをクリア
     }
   }, [calculateResult, checkRomajiMatch, currentKana, currentKanaIndex, currentTextIndex, inputBuffer, isMapLoaded, mistakes, router, isGameStarted, typingUnits]);


### PR DESCRIPTION
  概要 (Overview)

  このプルリクエストは、タイピング練習後の結果画面におけるユーザー体験を
  向上させるためのものです。


  従来のミスタイプ一覧は、どの文脈で間違えたのかが分かりにくいという課題
  がありました。また、苦手なキーを示すキーボードの色分けも、色の濃淡が何
  を意味するのかが直感的に理解しづらい状態でした。


  これらの課題を解決するため、以下の2点を中心にUIを大幅に改善しました。

   1. インタラクティブなミス箇所ハイライト機能の実装
   2. キーボードの視認性向上と凡例の追加

  変更点 (Changes)


   * `TypingGame.tsx`
       * localStorage に保存するタイピング結果に、練習した全文 (typedText)
          と、各ミスの発生箇所を示すインデックス (kanaIndex)
         を追加しました。


   * `ResultDisplay.tsx`
       * 従来のリスト形式のミス一覧を廃止しました。
       * 練習した全文を表示し、ミスがあった文字を赤色の波線でハイライトす
         る方式に変更しました。
       * ハイライトされた文字にマウスカーソルを合わせると、期待された入力
         と実際の入力をツールチップで表示する機能を追加しました。
       * 「苦手なキー」を表示するキーボードの下に、色の濃淡がミスの多さを
         示すことを説明する凡例を追加しました。

   * `OnScreenKeyboard.tsx`
       * 結果画面に表示されるキーボードのサイズを全体的に大きくし、各キー
         の視認性を向上させました。


  確認方法 (How to Test)


   1. vercel dev もしくは npm run dev でローカル開発サーバーを起動します。
   2. タイピング練習を開始し、意図的にいくつかミスをしながら練習を完了しま
      す。
   3. 結果画面に遷移し、以下の点を確認してください。
       * [x] 以前の箇条書きのミス一覧が表示されていないこと。
       * [x] 練習した全文が表示され、ミスした文字が赤色の波線でハイライト
         されていること。
       * [x] ハイライトされた文字にマウスを乗せると、ミスの詳細（期待入力
         vs 実際入力）がツールチップで表示されること。
       * [ ]
         「苦手なキー」のキーボードが以前より大きく表示されていること。
       * [x] キーボードの下に、色の濃淡の意味を示す凡例（「ミスが少ない」⇔
         「ミスが多い」）が表示されていること。