### PR TITLE
refactor: コード構造と状態管理の改善

### DIFF
--- a/src/components/ResultDisplay.tsx
+++ b/src/components/ResultDisplay.tsx
@@ -3,58 +3,14 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import OnScreenKeyboard from './OnScreenKeyboard';
-
-interface TypingResult {
-  accuracy: number;
-  wpm: number;
-  mistakes: { char: string; expected: string; actual: string; typedKey: string; kanaIndex: number }[];
-  startTime: number;
-  endTime: number;
-  totalKeystrokes: number;
-  correctKeystrokes: number;
-  correctKanaUnits: number;
-  typedText: string;
-  displayUnits: string[];
-}
-
-interface MistakeDetails {
-  [index: number]: { 
-    char: string;
-    expected: string;
-    actual: string; 
-  }[];
-}
-
-interface MistypedKeys {
-  [key: string]: number;
-}
-
-const createMistakeDetails = (mistakes: TypingResult['mistakes']): MistakeDetails => {
-  const details: MistakeDetails = {};
-  mistakes.forEach(mistake => {
-    if (!details[mistake.kanaIndex]) {
-      details[mistake.kanaIndex] = [];
-    }
-    details[mistake.kanaIndex].push({
-      char: mistake.char,
-      expected: mistake.expected,
-      actual: mistake.actual 
-    });
-  });
-  return details;
-};
-
-const analyzeMistypedKeys = (mistakes: TypingResult['mistakes']): MistypedKeys => {
-  const analysis: MistypedKeys = {};
-  mistakes.forEach(mistake => {
-    const key = mistake.typedKey.toLowerCase();
-    if (!analysis[key]) {
-      analysis[key] = 0;
-    }
-    analysis[key]++;
-  });
-  return analysis;
-};
+import { TypingResult } from '@/types/typing';
+import { LOCAL_STORAGE_RESULT_KEY } from '@/constants/typing';
+import { 
+  MistakeDetails, 
+  MistypedKeys, 
+  createMistakeDetails, 
+  analyzeMistypedKeys 
+} from '@/utils/resultUtils';
 
 const ResultDisplay: React.FC = () => {
   const [result, setResult] = useState<TypingResult | null>(null);
@@ -63,7 +19,7 @@ const ResultDisplay: React.FC = () => {
   const [tooltip, setTooltip] = useState<{ content: string; x: number; y: number } | null>(null);
 
   useEffect(() => {
-    const storedResult = localStorage.getItem('typingResult');
+    const storedResult = localStorage.getItem(LOCAL_STORAGE_RESULT_KEY);
     if (storedResult) {
       const parsedResult: TypingResult = JSON.parse(storedResult);
       setResult(parsedResult);

--- a/src/constants/typing.ts
+++ b/src/constants/typing.ts
@@ -1,0 +1,12 @@
+// src/constants/typing.ts
+
+/**
+ * 練習用の文章
+ * 将来的にはAPIやデータベースから取得するように拡張する
+ */
+export const TYPING_TEXTS = ["わがはいはねこである。", "て。すと。", "あいうえお"];
+
+/**
+ * タイピング結果をlocalStorageに保存する際のキー
+ */
+export const LOCAL_STORAGE_RESULT_KEY = 'typingResult';

--- a/src/types/typing.d.ts
+++ b/src/types/typing.d.ts
@@ -1,0 +1,29 @@
+// src/types/typing.d.ts
+
+/**
+ * ミスタイプ一回分の詳細情報
+ */
+export interface Mistake {
+  char: string; // ミスした対象の仮名
+  expected: string; // 期待されていたローマ字入力
+  actual: string; // 実際のローマ字入力
+  typedKey: string; // 実際にタイプされたキー
+  kanaIndex: number; // 文章全体における仮名のインデックス
+}
+
+/**
+ * 1回のタイピングゲーム全体の結果
+ * localStorageやデータベースに保存される際の型
+ */
+export interface TypingResult {
+  accuracy: number; // 正確性 (%)
+  wpm: number; // Words Per Minute
+  mistakes: Mistake[]; // ミスの詳細配列
+  startTime: number; // 開始時刻 (Unixタイムスタンプ)
+  endTime: number; // 終了時刻 (Unixタイムスタンプ)
+  totalKeystrokes: number; // 総打鍵数
+  correctKeystrokes: number; // 正解打鍵数
+  correctKanaUnits: number; // 正解仮名数
+  typedText: string; // 対象となった文章全体
+  displayUnits: string[]; // 表示用に分割された仮名の配列
+}

--- a/src/utils/resultUtils.ts
+++ b/src/utils/resultUtils.ts
@@ -1,0 +1,59 @@
+// src/utils/resultUtils.ts
+
+import { TypingResult, Mistake } from "@/types/typing";
+
+/**
+ * ミスの詳細情報を格納するオブジェクトの型
+ * キーは仮名のインデックス
+ */
+export interface MistakeDetails {
+  [index: number]: {
+    char: string;
+    expected: string;
+    actual: string;
+  }[];
+}
+
+/**
+ * ミスタイプされたキーとその回数を格納するオブジェクトの型
+ */
+export interface MistypedKeys {
+  [key: string]: number;
+}
+
+/**
+ * ミスの配列から、仮名インデックスをキーとした詳細なミスマップを作成する
+ * @param mistakes - TypingResultから取得したミスの配列
+ * @returns 仮名インデックスごとのミスの詳細
+ */
+export const createMistakeDetails = (mistakes: Mistake[]): MistakeDetails => {
+  const details: MistakeDetails = {};
+  mistakes.forEach(mistake => {
+    if (!details[mistake.kanaIndex]) {
+      details[mistake.kanaIndex] = [];
+    }
+    details[mistake.kanaIndex].push({
+      char: mistake.char,
+      expected: mistake.expected,
+      actual: mistake.actual
+    });
+  });
+  return details;
+};
+
+/**
+ * ミスの配列から、どのキーで何回ミスしたかを分析する
+ * @param mistakes - TypingResultから取得したミスの配列
+ * @returns キーごとのミス回数
+ */
+export const analyzeMistypedKeys = (mistakes: Mistake[]): MistypedKeys => {
+  const analysis: MistypedKeys = {};
+  mistakes.forEach(mistake => {
+    const key = mistake.typedKey.toLowerCase();
+    if (!analysis[key]) {
+      analysis[key] = 0;
+    }
+    analysis[key]++;
+  });
+  return analysis;
+};


### PR DESCRIPTION
保守性と拡張性を向上させるためのリファクタリングを実施。

主な変更点:
- 共有の型定義を `src/types/` に分離
- 定数を `src/constants/` に分離
- 結果表示コンポーネントからロジックを `src/utils/` に分離
- `useTypingGame` フックの状態管理を `useState` から `useReducer` に変更し、状態遷移のロジックを集約

これにより、将来的な機能追加（データベース連携など）が容易な、より堅牢なコードベースとなりました。