### PR TITLE
 feat(history): 成績履歴・苦手分析の期間別表示とUI/UX改善

### DIFF
--- a/src/components/HistoryChart.tsx
+++ b/src/components/HistoryChart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { TypingResult } from '@prisma/client';
+import { HistoryResult } from '@/types/typing';
 import {
   LineChart,
   Line,
@@ -12,13 +12,8 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 
-// page.tsxから渡される結果の型。Dateが文字列にシリアライズされている。
-type SerializableResult = Omit<TypingResult, 'createdAt'> & {
-  createdAt: string;
-};
-
 interface HistoryChartProps {
-  results: SerializableResult[];
+  results: HistoryResult[];
 }
 
 export default function HistoryChart({ results }: HistoryChartProps) {

--- a/src/components/HistoryChart.tsx
+++ b/src/components/HistoryChart.tsx
@@ -31,7 +31,7 @@ export default function HistoryChart({ results }: HistoryChartProps) {
     .reverse(); // 時系列で表示するために配列を逆順にする
 
   return (
-    <div className="w-full h-80 bg-white p-4 rounded-lg shadow-md mb-8">
+    <div className="w-full h-80 bg-white p-4 rounded-lg shadow-md">
       <ResponsiveContainer>
         <LineChart
           data={chartData}

--- a/src/components/HistoryChart.tsx
+++ b/src/components/HistoryChart.tsx
@@ -25,7 +25,6 @@ export default function HistoryChart({ results }: HistoryChartProps) {
         month: 'numeric',
         day: 'numeric',
       }),
-      スコア: result.score,
       WPM: parseFloat(result.wpm.toFixed(2)),
       正解率: parseFloat(result.accuracy.toFixed(2)),
     }))
@@ -40,20 +39,18 @@ export default function HistoryChart({ results }: HistoryChartProps) {
             top: 5,
             right: 20,
             left: 10,
-            bottom: 5,
+            bottom: 30,
           }}
         >
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="date" />
-          <YAxis yAxisId="score" label={{ value: 'スコア', angle: -90, position: 'insideLeft' }} stroke="#ffc658" />
-          <YAxis yAxisId="wpm" orientation="right" label={{ value: 'WPM', angle: 90, position: 'insideRight' }} stroke="#8884d8" />
-          <YAxis yAxisId="accuracy" orientation="right" domain={[0, 100]} hide />
+          <YAxis yAxisId="wpm" label={{ value: 'WPM', angle: -90, position: 'insideLeft' }} stroke="#8884d8" />
+          <YAxis yAxisId="accuracy" orientation="right" label={{ value: '正解率 (%)', angle: 90, position: 'insideRight' }} stroke="#82ca9d" domain={[0, 100]} />
           
           <Tooltip />
           <Legend />
           
-          <Line yAxisId="score" type="monotone" dataKey="スコア" stroke="#ffc658" strokeWidth={2} activeDot={{ r: 6 }} />
-          <Line yAxisId="wpm" type="monotone" dataKey="WPM" stroke="#8884d8" />
+          <Line yAxisId="wpm" type="monotone" dataKey="WPM" stroke="#8884d8" activeDot={{ r: 8 }} />
           <Line yAxisId="accuracy" type="monotone" dataKey="正解率" stroke="#82ca9d" />
         </LineChart>
       </ResponsiveContainer>

--- a/src/components/HistoryChart.tsx
+++ b/src/components/HistoryChart.tsx
@@ -25,6 +25,7 @@ export default function HistoryChart({ results }: HistoryChartProps) {
         month: 'numeric',
         day: 'numeric',
       }),
+      スコア: result.score,
       WPM: parseFloat(result.wpm.toFixed(2)),
       正解率: parseFloat(result.accuracy.toFixed(2)),
     }))
@@ -44,12 +45,16 @@ export default function HistoryChart({ results }: HistoryChartProps) {
         >
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="date" />
-          <YAxis yAxisId="left" label={{ value: 'WPM', angle: -90, position: 'insideLeft' }} />
-          <YAxis yAxisId="right" orientation="right" label={{ value: '正解率 (%)', angle: 90, position: 'insideRight' }} />
+          <YAxis yAxisId="score" label={{ value: 'スコア', angle: -90, position: 'insideLeft' }} stroke="#ffc658" />
+          <YAxis yAxisId="wpm" orientation="right" label={{ value: 'WPM', angle: 90, position: 'insideRight' }} stroke="#8884d8" />
+          <YAxis yAxisId="accuracy" orientation="right" domain={[0, 100]} hide />
+          
           <Tooltip />
           <Legend />
-          <Line yAxisId="left" type="monotone" dataKey="WPM" stroke="#8884d8" activeDot={{ r: 8 }} />
-          <Line yAxisId="right" type="monotone" dataKey="正解率" stroke="#82ca9d" />
+          
+          <Line yAxisId="score" type="monotone" dataKey="スコア" stroke="#ffc658" strokeWidth={2} activeDot={{ r: 6 }} />
+          <Line yAxisId="wpm" type="monotone" dataKey="WPM" stroke="#8884d8" />
+          <Line yAxisId="accuracy" type="monotone" dataKey="正解率" stroke="#82ca9d" />
         </LineChart>
       </ResponsiveContainer>
     </div>

--- a/src/components/HistoryTable.tsx
+++ b/src/components/HistoryTable.tsx
@@ -1,68 +1,184 @@
 'use client';
 
+import { useState } from 'react';
 import { HistoryResult } from '@/types/typing';
 
 interface HistoryTableProps {
   results: HistoryResult[];
 }
 
+const ITEMS_PER_PAGE = 20;
+
 export default function HistoryTable({ results }: HistoryTableProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const totalPages = Math.ceil(results.length / ITEMS_PER_PAGE);
+
+  const visibleResults = !isExpanded
+    ? results.slice(0, 10)
+    : results.slice((currentPage - 1) * ITEMS_PER_PAGE, currentPage * ITEMS_PER_PAGE);
+
+  const handlePageChange = (page: number) => {
+    if (page >= 1 && page <= totalPages) {
+      setCurrentPage(page);
+    }
+  };
+
+  // ページネーションのボタン生成（現在のページの前後を表示）
+  const getPageNumbers = () => {
+    const pages = [];
+    const maxVisiblePages = 5;
+    let start = Math.max(1, currentPage - Math.floor(maxVisiblePages / 2));
+    const end = Math.min(totalPages, start + maxVisiblePages - 1);
+
+    if (end - start + 1 < maxVisiblePages) {
+      start = Math.max(1, end - maxVisiblePages + 1);
+    }
+
+    for (let i = start; i <= end; i++) {
+      pages.push(i);
+    }
+    return pages;
+  };
+
   return (
-    <div className="overflow-x-auto relative shadow-md sm:rounded-lg">
-      <table className="w-full text-sm text-left text-gray-500">
-        <thead className="text-xs text-gray-700 uppercase bg-gray-50">
-          <tr>
-            <th scope="col" className="py-3 px-6">
-              実施日時
-            </th>
-            <th scope="col" className="py-3 px-6">
-              スコア
-            </th>
-            <th scope="col" className="py-3 px-6">
-              WPM
-            </th>
-            <th scope="col" className="py-3 px-6">
-              正解率
-            </th>
-            <th scope="col" className="py-3 px-6">
-              ミス回数
-            </th>
-            <th scope="col" className="py-3 px-6">
-              練習文章
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {results.map((result) => (
-            <tr key={result.id} className="bg-white border-b hover:bg-gray-50">
-              <th scope="row" className="py-4 px-6 font-medium text-gray-900 whitespace-nowrap">
-                {new Date(result.createdAt).toLocaleString('ja-JP', {
-                  year: 'numeric',
-                  month: 'long',
-                  day: 'numeric',
-                  hour: '2-digit',
-                  minute: '2-digit',
-                })}
+    <div className="flex flex-col gap-4">
+      <div className="overflow-x-auto relative shadow-md sm:rounded-lg">
+        <table className="w-full text-sm text-left text-gray-500">
+          <thead className="text-xs text-gray-700 uppercase bg-gray-50">
+            <tr>
+              <th scope="col" className="py-3 px-6">
+                実施日時
               </th>
-              <td className="py-4 px-6 font-semibold text-gray-900">
-                {result.score}
-              </td>
-              <td className="py-4 px-6">
-                {result.wpm.toFixed(2)}
-              </td>
-              <td className="py-4 px-6">
-                {result.accuracy.toFixed(2)}%
-              </td>
-              <td className="py-4 px-6">
-                {result.mistakeCount}
-              </td>
-              <td className="py-4 px-6 max-w-xs truncate" title={result.text}>
-                {result.text}
-              </td>
+              <th scope="col" className="py-3 px-6">
+                スコア
+              </th>
+              <th scope="col" className="py-3 px-6">
+                WPM
+              </th>
+              <th scope="col" className="py-3 px-6">
+                正解率
+              </th>
+              <th scope="col" className="py-3 px-6">
+                ミス回数
+              </th>
+              <th scope="col" className="py-3 px-6">
+                練習文章
+              </th>
             </tr>
+          </thead>
+          <tbody>
+            {visibleResults.map((result) => (
+              <tr key={result.id} className="bg-white border-b hover:bg-gray-50">
+                <th scope="row" className="py-4 px-6 font-medium text-gray-900 whitespace-nowrap">
+                  {new Date(result.createdAt).toLocaleString('ja-JP', {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                  })}
+                </th>
+                <td className="py-4 px-6 font-semibold text-gray-900">
+                  {result.score}
+                </td>
+                <td className="py-4 px-6">
+                  {result.wpm.toFixed(2)}
+                </td>
+                <td className="py-4 px-6">
+                  {result.accuracy.toFixed(2)}%
+                </td>
+                <td className="py-4 px-6">
+                  {result.mistakeCount}
+                </td>
+                <td className="py-4 px-6 max-w-xs truncate" title={result.text}>
+                  {result.text}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* 「もっと見る」トグルボタン */}
+      {!isExpanded && results.length > 10 && (
+        <div className="flex justify-center">
+          <button
+            onClick={() => setIsExpanded(true)}
+            className="flex items-center gap-2 px-6 py-3 bg-white border border-gray-300 rounded-full shadow-sm text-gray-700 font-medium hover:bg-gray-50 hover:text-blue-600 transition-colors"
+          >
+            <span>すべての履歴を見る ({results.length}件)</span>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-4 h-4">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+            </svg>
+          </button>
+        </div>
+      )}
+
+      {/* ページネーション */}
+      {isExpanded && totalPages > 1 && (
+        <div className="flex justify-center items-center gap-2 py-2">
+          <button
+            onClick={() => handlePageChange(1)}
+            disabled={currentPage === 1}
+            className="p-2 rounded-md border border-gray-300 hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed"
+            aria-label="最初のページ"
+          >
+            &laquo;
+          </button>
+          <button
+            onClick={() => handlePageChange(currentPage - 1)}
+            disabled={currentPage === 1}
+            className="p-2 rounded-md border border-gray-300 hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed"
+            aria-label="前のページ"
+          >
+            &lt;
+          </button>
+
+          {getPageNumbers().map((page) => (
+            <button
+              key={page}
+              onClick={() => handlePageChange(page)}
+              className={`w-10 h-10 flex items-center justify-center rounded-md border ${
+                currentPage === page
+                  ? 'bg-blue-600 text-white border-blue-600'
+                  : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+              }`}
+            >
+              {page}
+            </button>
           ))}
-        </tbody>
-      </table>
+
+          <button
+            onClick={() => handlePageChange(currentPage + 1)}
+            disabled={currentPage === totalPages}
+            className="p-2 rounded-md border border-gray-300 hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed"
+            aria-label="次のページ"
+          >
+            &gt;
+          </button>
+          <button
+            onClick={() => handlePageChange(totalPages)}
+            disabled={currentPage === totalPages}
+            className="p-2 rounded-md border border-gray-300 hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed"
+            aria-label="最後のページ"
+          >
+            &raquo;
+          </button>
+        </div>
+      )}
+      
+      {isExpanded && (
+          <div className="flex justify-center">
+            <button 
+                onClick={() => { setIsExpanded(false); setCurrentPage(1); }}
+                className="text-sm text-gray-500 hover:text-gray-700 underline"
+            >
+                履歴を閉じる
+            </button>
+          </div>
+      )}
     </div>
   );
 }

--- a/src/components/HistoryTable.tsx
+++ b/src/components/HistoryTable.tsx
@@ -1,14 +1,9 @@
 'use client';
 
-import { TypingResult } from '@prisma/client';
-
-// page.tsxから渡される結果の型。Dateが文字列にシリアライズされている。
-type SerializableResult = Omit<TypingResult, 'createdAt'> & {
-  createdAt: string;
-};
+import { HistoryResult } from '@/types/typing';
 
 interface HistoryTableProps {
-  results: SerializableResult[];
+  results: HistoryResult[];
 }
 
 export default function HistoryTable({ results }: HistoryTableProps) {

--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -58,23 +58,37 @@ const HistoryView: React.FC<HistoryViewProps> = ({ results, weaknessAnalysis }) 
 
       {results.length > 0 ? (
         <>
-            {/* 苦手分析 */}
-            <section className="bg-white p-6 rounded-xl shadow-sm border border-gray-200">
-                <div className="mb-4 pb-2 border-b border-gray-100">
-                    <h2 className="text-xl font-bold text-gray-800">
-                        🎯 苦手分析 <span className="text-sm font-normal text-gray-500 ml-2">({TIME_RANGES.find(r => r.value === currentRange)?.label})</span>
+            {/* 分析レポート（グラフ＆苦手分析） */}
+            <section className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+                <div className="p-6 border-b border-gray-100 bg-gray-50 flex justify-between items-center">
+                    <h2 className="text-xl font-bold text-gray-800 flex items-center gap-2">
+                        📊 分析レポート
+                        <span className="text-sm font-normal text-gray-500 bg-white px-2 py-1 rounded border">
+                            {TIME_RANGES.find(r => r.value === currentRange)?.label}
+                        </span>
                     </h2>
                 </div>
-                <WeaknessAnalysisDisplay analysis={weaknessAnalysis} />
-            </section>
+                
+                <div className="p-6 space-y-8">
+                    {/* 成績推移チャート */}
+                    <div>
+                        <h3 className="text-lg font-semibold text-gray-700 mb-4 border-l-4 border-blue-500 pl-3">
+                            📈 成績推移 (スコア・WPM・正確性)
+                        </h3>
+                        <div className="h-[400px] w-full">
+                            <HistoryChart results={results} />
+                        </div>
+                    </div>
 
-            {/* グラフ */}
-            <section className="bg-white p-6 rounded-xl shadow-sm border border-gray-200">
-                <div className="mb-4 pb-2 border-b border-gray-100">
-                    <h2 className="text-xl font-bold text-gray-800">📈 成績推移</h2>
-                </div>
-                <div className="h-[400px] w-full">
-                    <HistoryChart results={results} />
+                    <div className="border-t border-gray-100 pt-8"></div>
+
+                    {/* 苦手分析 */}
+                    <div>
+                        <h3 className="text-lg font-semibold text-gray-700 mb-4 border-l-4 border-red-500 pl-3">
+                            🎯 苦手傾向分析
+                        </h3>
+                        <WeaknessAnalysisDisplay analysis={weaknessAnalysis} />
+                    </div>
                 </div>
             </section>
 

--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import React, { useCallback } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { HistoryResult } from '@/types/typing';
+import HistoryChart from './HistoryChart';
+import HistoryTable from './HistoryTable';
+import WeaknessAnalysisDisplay from './WeaknessAnalysisDisplay';
+import { WeaknessAnalysis } from '@/utils/analysisUtils';
+
+interface HistoryViewProps {
+  results: HistoryResult[];
+  weaknessAnalysis: WeaknessAnalysis;
+}
+
+const TIME_RANGES = [
+  { label: '1週間', value: 'week' },
+  { label: '1ヶ月', value: 'month' },
+  { label: '1年', value: 'year' },
+  { label: '全期間', value: 'all' },
+];
+
+const HistoryView: React.FC<HistoryViewProps> = ({ results, weaknessAnalysis }) => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const currentRange = searchParams.get('range') || 'all';
+
+  const handleRangeChange = useCallback((range: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (range === 'all') {
+      params.delete('range');
+    } else {
+      params.set('range', range);
+    }
+    router.push(`/history?${params.toString()}`);
+  }, [router, searchParams]);
+
+  return (
+    <div className="space-y-8">
+      {/* 期間切り替えタブ */}
+      <div className="flex justify-center">
+        <div className="inline-flex bg-gray-100 p-1 rounded-lg">
+          {TIME_RANGES.map((range) => (
+            <button
+              key={range.value}
+              onClick={() => handleRangeChange(range.value)}
+              className={`px-4 py-2 rounded-md text-sm font-medium transition-colors duration-200 ${
+                currentRange === range.value
+                  ? 'bg-white text-blue-600 shadow-sm'
+                  : 'text-gray-500 hover:text-gray-700 hover:bg-gray-200'
+              }`}
+            >
+              {range.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {results.length > 0 ? (
+        <>
+            {/* 苦手分析 */}
+            <section className="bg-white p-6 rounded-xl shadow-sm border border-gray-200">
+                <div className="mb-4 pb-2 border-b border-gray-100">
+                    <h2 className="text-xl font-bold text-gray-800">
+                        🎯 苦手分析 <span className="text-sm font-normal text-gray-500 ml-2">({TIME_RANGES.find(r => r.value === currentRange)?.label})</span>
+                    </h2>
+                </div>
+                <WeaknessAnalysisDisplay analysis={weaknessAnalysis} />
+            </section>
+
+            {/* グラフ */}
+            <section className="bg-white p-6 rounded-xl shadow-sm border border-gray-200">
+                <div className="mb-4 pb-2 border-b border-gray-100">
+                    <h2 className="text-xl font-bold text-gray-800">📈 成績推移</h2>
+                </div>
+                <div className="h-[400px] w-full">
+                    <HistoryChart results={results} />
+                </div>
+            </section>
+
+            {/* 履歴テーブル */}
+            <section className="bg-white p-6 rounded-xl shadow-sm border border-gray-200">
+                <div className="mb-4 pb-2 border-b border-gray-100">
+                    <h2 className="text-xl font-bold text-gray-800">📝 詳細履歴</h2>
+                </div>
+                <HistoryTable results={results} />
+            </section>
+        </>
+      ) : (
+        <div className="text-center py-12 bg-white rounded-xl shadow-sm border border-dashed border-gray-300">
+          <p className="text-gray-500 text-lg">
+            選択された期間のデータはありません。<br />
+            練習をして記録を作りましょう！
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default HistoryView;

--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -36,40 +36,37 @@ const HistoryView: React.FC<HistoryViewProps> = ({ results, weaknessAnalysis }) 
   }, [router, searchParams]);
 
   return (
-    <div className="space-y-8">
-      {/* 期間切り替えタブ */}
-      <div className="flex justify-center">
-        <div className="inline-flex bg-gray-100 p-1 rounded-lg">
-          {TIME_RANGES.map((range) => (
-            <button
-              key={range.value}
-              onClick={() => handleRangeChange(range.value)}
-              className={`px-4 py-2 rounded-md text-sm font-medium transition-colors duration-200 ${
-                currentRange === range.value
-                  ? 'bg-white text-blue-600 shadow-sm'
-                  : 'text-gray-500 hover:text-gray-700 hover:bg-gray-200'
-              }`}
-            >
-              {range.label}
-            </button>
-          ))}
-        </div>
-      </div>
-
+    <div className="space-y-6"> {/* Reduced space-y here */}
       {results.length > 0 ? (
         <>
             {/* 分析レポート（グラフ＆苦手分析） */}
             <section className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
-                <div className="p-6 border-b border-gray-100 bg-gray-50 flex justify-between items-center">
+                <div className="p-6 border-b border-gray-100 bg-gray-50 flex flex-col sm:flex-row justify-between sm:items-center gap-4">
                     <h2 className="text-xl font-bold text-gray-800 flex items-center gap-2">
                         📊 分析レポート
                         <span className="text-sm font-normal text-gray-500 bg-white px-2 py-1 rounded border">
                             {TIME_RANGES.find(r => r.value === currentRange)?.label}
                         </span>
                     </h2>
+                    {/* 期間切り替えタブ */}
+                    <div className="inline-flex bg-gray-100 p-1 rounded-lg">
+                        {TIME_RANGES.map((range) => (
+                            <button
+                            key={range.value}
+                            onClick={() => handleRangeChange(range.value)}
+                            className={`px-4 py-2 rounded-md text-sm font-medium transition-colors duration-200 ${
+                                currentRange === range.value
+                                ? 'bg-white text-blue-600 shadow-sm'
+                                : 'text-gray-500 hover:text-gray-700 hover:bg-gray-200'
+                            }`}
+                            >
+                            {range.label}
+                            </button>
+                        ))}
+                    </div>
                 </div>
                 
-                <div className="p-6 space-y-6">
+                <div className="p-4 space-y-4"> {/* Reduced p and space-y here */}
                     {/* 苦手分析 */}
                     <div>
                         <h3 className="text-lg font-semibold text-gray-700 mb-4 border-l-4 border-red-500 pl-3">
@@ -78,7 +75,7 @@ const HistoryView: React.FC<HistoryViewProps> = ({ results, weaknessAnalysis }) 
                         <WeaknessAnalysisDisplay analysis={weaknessAnalysis} />
                     </div>
 
-                    <div className="border-t border-gray-100 pt-6"></div>
+                    <div className="border-t border-gray-100 pt-4"></div> {/* Reduced pt here */}
 
                     {/* 成績推移チャート */}
                     <div>

--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -69,25 +69,25 @@ const HistoryView: React.FC<HistoryViewProps> = ({ results, weaknessAnalysis }) 
                     </h2>
                 </div>
                 
-                <div className="p-6 space-y-8">
-                    {/* 成績推移チャート */}
-                    <div>
-                        <h3 className="text-lg font-semibold text-gray-700 mb-4 border-l-4 border-blue-500 pl-3">
-                            📈 成績推移 (スコア・WPM・正確性)
-                        </h3>
-                        <div className="h-[400px] w-full">
-                            <HistoryChart results={results} />
-                        </div>
-                    </div>
-
-                    <div className="border-t border-gray-100 pt-8"></div>
-
+                <div className="p-6 space-y-6">
                     {/* 苦手分析 */}
                     <div>
                         <h3 className="text-lg font-semibold text-gray-700 mb-4 border-l-4 border-red-500 pl-3">
                             🎯 苦手傾向分析
                         </h3>
                         <WeaknessAnalysisDisplay analysis={weaknessAnalysis} />
+                    </div>
+
+                    <div className="border-t border-gray-100 pt-6"></div>
+
+                    {/* 成績推移チャート */}
+                    <div>
+                        <h3 className="text-lg font-semibold text-gray-700 mb-4 border-l-4 border-blue-500 pl-3">
+                            📈 成績推移 (WPM・正確性)
+                        </h3>
+                        <div className="h-[400px] w-full">
+                            <HistoryChart results={results} />
+                        </div>
                     </div>
                 </div>
             </section>

--- a/src/types/typing.d.ts
+++ b/src/types/typing.d.ts
@@ -73,3 +73,21 @@ export interface Course {
   isPublic?: boolean; // マイページでの表示用
   texts?: TypingText[]; // 詳細取得時のみ含まれる (APIからのレスポンス用)
 }
+
+/**
+ * 履歴画面表示用の結果型 (Prismaモデルベース + createdAt文字列化)
+ */
+export interface HistoryResult {
+  id: string;
+  userId: string;
+  wpm: number;
+  accuracy: number;
+  mistakeCount: number;
+  score: number;
+  totalKeystrokes: number;
+  correctKeystrokes: number;
+  text: string;
+  mistakeDetails: string; // JSON string in DB
+  createdAt: string; // Serialized date
+  courseId: string | null;
+}


### PR DESCRIPTION
   - 期間絞り込み機能の追加:
       * 成績履歴および苦手分析画面で、「1週間」「1ヶ月」「1年」「全期間」でデータを絞り込める期間選択U
         Iを導入しました。
       * URLクエリパラメータを利用し、Server Componentsで効率的にデータをフィルタリングします。
   - 分析レポートUIの統合と改善:
       * 「苦手分析」と「成績推移グラフ」を一つの「📊 分析レポート」セクションに統合しました。
       * 期間選択UIもレポートヘッダー内に配置し、レポートと密接に連携するようにしました。
       * レイアウトの順序を「苦手傾向分析」を上、「成績推移グラフ」を下に変更し、余白を最適化しました。
   - チャートの改善:
       * 「スコア」の表示を削除し、WPMと正確性の2軸構成に戻しました。
       * X軸のラベルが見切れないよう、グラフ下部のマージンを調整しました。
       * チャートコンポーネントの不要な下部マージンを削除し、親コンポーネントでレイアウト制御するように
         しました。
   - 履歴テーブルのページネーション機能:
       * 「詳細履歴」テーブルにクライアントサイドのページネーション機能を追加しました。
       * 初期表示は最新10件のみとし、「すべての履歴を見る」ボタンで全件表示（1ページ20件のページネーシ
         ョン付き）に切り替え可能です。
   - パフォーマンスとコード品質の向上:
       * 履歴データ変換処理を最適化し、rawResults のループ回数を削減しました。
       * HistoryResult 型を導入し、データ型の整合性を確保することで、型エラーを修正しました。